### PR TITLE
Fix card-action wrap settings

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -390,3 +390,8 @@ code, kbd {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale
 }
+
+.card-action {
+  white-space: nowrap;
+}
+


### PR DESCRIPTION
Set white-space to `nowrap` so cards look better.

```css
.card-action {
  white-space: nowrap;
}
```
# Change this:
![image](https://github.com/Chew/chew.github.io/assets/11000195/a7ec43b7-b606-4088-8f69-0aeb5d8edbc3)

# To this:
![image](https://github.com/Chew/chew.github.io/assets/11000195/df40bd11-4b96-4934-a01e-9245fa4ca118)
